### PR TITLE
Feat [#25] 뷰 플로우 연결

### DIFF
--- a/Airbnb-iOS/Source/Scenes/Helper/CustomNavigationView.swift
+++ b/Airbnb-iOS/Source/Scenes/Helper/CustomNavigationView.swift
@@ -17,6 +17,8 @@ class CustomNavigationView: UIView {
     
     // MARK: - Variables
     // MARK: Constants
+    let isLongerView = UIScreen.main.isLongerThan812pt
+    
     // MARK: Property
     var progressLevel: Float = 0.0
     
@@ -90,43 +92,72 @@ class CustomNavigationView: UIView {
     
     // MARK: Layout Helpers
     private func setUI(){
-        setStyle()
-        setLayout()
+        setViewHierarchy()
+        setConstraints()
     }
     
-    private func setStyle() { }
-    
-    private func setLayout() {
+    private func setViewHierarchy() {
         self.addSubviews(xButton, labelStackView, selectLineView, progressBarView)
-        
-        self.snp.makeConstraints {
-            $0.height.equalTo(128.adjustedHeight)
+    }
+    
+    private func setConstraints() {
+        if isLongerView {
+            self.snp.makeConstraints {
+                $0.height.equalTo(128.adjustedHeight)
+            }
+            
+            xButton.snp.makeConstraints {
+                $0.top.equalToSuperview().offset(57.adjusted)
+                $0.leading.equalToSuperview().offset(16.adjusted)
+                $0.size.equalTo(42.adjusted)
+            }
+            
+            selectLineView.snp.makeConstraints {
+                $0.top.equalTo(lodgingLabel.snp.bottom).offset(5)
+                $0.centerX.equalTo(lodgingLabel.snp.centerX)
+                $0.height.equalTo(2.adjustedHeight)
+                $0.width.equalTo(lodgingLabel.snp.width)
+            }
+            
+            labelStackView.snp.makeConstraints {
+                $0.centerY.equalTo(xButton.snp.centerY)
+                $0.centerX.equalToSuperview()
+            }
+            
+            progressBarView.snp.makeConstraints {
+                $0.height.equalTo(8.adjustedHeight)
+                $0.bottom.equalToSuperview()
+                $0.leading.trailing.equalToSuperview().inset(21.adjusted)
+            }
+        } else {
+            self.snp.makeConstraints {
+                $0.height.equalTo(110.adjustedHeight)
+            }
+            
+            xButton.snp.makeConstraints {
+                $0.top.equalToSuperview().offset(49.adjusted)
+                $0.leading.equalToSuperview().offset(14.adjusted)
+                $0.size.equalTo(36.adjusted)
+            }
+            
+            selectLineView.snp.makeConstraints {
+                $0.top.equalTo(lodgingLabel.snp.bottom).offset(5)
+                $0.centerX.equalTo(lodgingLabel.snp.centerX)
+                $0.height.equalTo(2.adjustedHeight)
+                $0.width.equalTo(lodgingLabel.snp.width)
+            }
+            
+            labelStackView.snp.makeConstraints {
+                $0.centerY.equalTo(xButton.snp.centerY)
+                $0.centerX.equalToSuperview()
+            }
+            
+            progressBarView.snp.makeConstraints {
+                $0.height.equalTo(6.adjustedHeight)
+                $0.bottom.equalToSuperview()
+                $0.leading.trailing.equalToSuperview().inset(18.adjusted)
+            }
         }
-        
-        xButton.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(57.adjusted)
-            $0.leading.equalToSuperview().offset(16.adjusted)
-            $0.size.equalTo(42.adjusted)
-        }
-        
-        selectLineView.snp.makeConstraints {
-            $0.top.equalTo(lodgingLabel.snp.bottom).offset(5)
-            $0.centerX.equalTo(lodgingLabel.snp.centerX)
-            $0.height.equalTo(2.adjustedHeight)
-            $0.width.equalTo(lodgingLabel.snp.width)
-        }
-        
-        labelStackView.snp.makeConstraints {
-            $0.centerY.equalTo(xButton.snp.centerY)
-            $0.centerX.equalToSuperview()
-        }
-        
-        progressBarView.snp.makeConstraints {
-            $0.height.equalTo(8.adjustedHeight)
-            $0.bottom.equalToSuperview()
-            $0.leading.trailing.equalToSuperview().inset(21.adjusted)
-        }
-        
     }
     // MARK: Custom Function
     /// darkMode가 필요할 때 변경하는 함수입니다. 기본은 라이트모드

--- a/Airbnb-iOS/Source/Scenes/WhenScene/ViewControllers/WhenViewController.swift
+++ b/Airbnb-iOS/Source/Scenes/WhenScene/ViewControllers/WhenViewController.swift
@@ -56,7 +56,7 @@ class WhenViewController: UIViewController {
     
     // MARK: Objc Function
     @objc func nextButtonDidTap() {
-        navigationController?.pushViewController(WhoViewViewController(), animated: true)
+        navigationController?.pushViewController(WhoViewViewController(), animated: false)
     }
     
 }

--- a/Airbnb-iOS/Source/Scenes/WhenScene/Views/WhenView.swift
+++ b/Airbnb-iOS/Source/Scenes/WhenScene/Views/WhenView.swift
@@ -124,7 +124,6 @@ class WhenView: UIView {
         
         navigationBar.snp.makeConstraints {
             $0.top.leading.trailing.equalToSuperview()
-            $0.height.equalTo(128.adjusted)
         }
         
         titleLabel.snp.makeConstraints {

--- a/Airbnb-iOS/Source/Scenes/Where/WhereViewController.swift
+++ b/Airbnb-iOS/Source/Scenes/Where/WhereViewController.swift
@@ -99,7 +99,10 @@ extension WhereViewController: UICollectionViewDataSource{
     
 }
 extension WhereViewController: UICollectionViewDelegate{
-    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let nextViewConroller = WhenViewController()
+        navigationController?.pushViewController(nextViewConroller, animated: false)
+    }
 }
 
 extension WhereViewController {

--- a/Airbnb-iOS/Source/Scenes/WhoScene/Views/WhoView.swift
+++ b/Airbnb-iOS/Source/Scenes/WhoScene/Views/WhoView.swift
@@ -22,6 +22,7 @@ class WhoView: UIView {
     private let backgroundImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = ImageLiteral.imgWho
+        imageView.contentMode = .scaleAspectFill
         return imageView
     }()
     

--- a/Airbnb-iOS/Source/Supports/SceneDelegate.swift
+++ b/Airbnb-iOS/Source/Supports/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.windowScene = windowScene
-        window?.rootViewController = WhereViewController()
+        window?.rootViewController = TabBarController()
         window?.makeKeyAndVisible()
     }
     


### PR DESCRIPTION
## ⛏ 작업 내용
뷰 플로우를 연결했습니다. 
SE 기기 대응을 위해 커스텀 네비게이션바의 레이아웃을 변경했습니다. 


## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- SE 기기 대응을 위하여 커스텀 네비게이션을 다음과 같이 변경했습니다. 

> - Screen의 크기를 계산한 뒤 각 기기에 맞는 레이아웃을 적용합니다. 
``` swift
    let isLongerView = UIScreen.main.isLongerThan812pt
    
...
    
    private func setConstraints() {
        if isLongerView {
           // SE 외의 기기 레이아웃
        } else {
          // SE 레이아웃
        }
```


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| SE | ![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-12-01 at 03 46 48](https://github.com/DO-SOPT-APP3-Airbnb/Airbnb-iOS/assets/68178395/ea309f23-ec84-40ca-b47e-cf702de7937f)|
| 그 외 기기 (14pro) |![Simulator Screen Recording - iPhone 14 Pro - 2023-12-01 at 03 47 12](https://github.com/DO-SOPT-APP3-Airbnb/Airbnb-iOS/assets/68178395/1d79246a-9e7f-419f-89e3-12f84602c6b2)|


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #25 